### PR TITLE
Fix version conflict in ReadTheDocs 

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
     - openeye
     - rdkit
 dependencies:
-    - python==3.5
+    - python>=3.5.2
     - numpy
     - openeye-toolkits
     - rdkit


### PR DESCRIPTION
I was getting this error in my read the docs build:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/chemper/conda/latest/bin/sphinx-build", line 6, in <module>
    from sphinx.cmd.build import main
  File "/home/docs/checkouts/readthedocs.org/user_builds/chemper/conda/latest/lib/python3.5/site-packages/sphinx/cmd/build.py", line 22, in <module>
    from sphinx.application import Sphinx
  File "/home/docs/checkouts/readthedocs.org/user_builds/chemper/conda/latest/lib/python3.5/site-packages/sphinx/application.py", line 34, in <module>
    from sphinx.project import Project
  File "/home/docs/checkouts/readthedocs.org/user_builds/chemper/conda/latest/lib/python3.5/site-packages/sphinx/project.py", line 12, in <module>
    from typing import TYPE_CHECKING
ImportError: cannot import name 'TYPE_CHECKING'
```
Then I found [this discussion](https://github.com/rtfd/readthedocs.org/issues/3812) about version clashes. It looks like you need greater than python 3.5.2 and in my docs environment file I had python pinned to `python==3.5` which I guess was getting python 3.5.0. I switched to `python>=3.5.2` so hopefully this works