### PR TITLE
Fix installation doc typo

### DIFF
--- a/docs/api/single_graph.rst
+++ b/docs/api/single_graph.rst
@@ -1,7 +1,7 @@
 SingleGraph
 ============
 
-``SingleGraph``s convert a molecule into a SMIRKS pattern by
+``SingleGraph``\'s convert a molecule into a SMIRKS pattern by
 converting information about the atoms and bonds.
 The ``SingleGraph`` stores only one molecule. It can convert only certain atoms or
 the *entire* molecule into a SMIRKS pattern.

--- a/docs/api/single_graph.rst
+++ b/docs/api/single_graph.rst
@@ -1,7 +1,7 @@
 SingleGraph
 ============
 
-``SingleGraph``\ s convert a molecule into a SMIRKS pattern by
+A ``SingleGraph`` converts a molecule into a SMIRKS pattern by
 converting information about the atoms and bonds.
 The ``SingleGraph`` stores only one molecule. It can convert only certain atoms or
 the *entire* molecule into a SMIRKS pattern.

--- a/docs/api/single_graph.rst
+++ b/docs/api/single_graph.rst
@@ -1,7 +1,7 @@
 SingleGraph
 ============
 
-``SingleGraph``\'s convert a molecule into a SMIRKS pattern by
+``SingleGraph``\ s convert a molecule into a SMIRKS pattern by
 converting information about the atoms and bonds.
 The ``SingleGraph`` stores only one molecule. It can convert only certain atoms or
 the *entire* molecule into a SMIRKS pattern.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,7 +41,7 @@ Conda installation according to `OpenEye documentation <https://docs.eyesopen.co
 
 .. code-block:: bash
 
-    cond install -c openeye openeye-toolkits
+    conda install -c openeye openeye-toolkits
 
 Installation
 ------------


### PR DESCRIPTION
Typo fix for the installation page in the docs